### PR TITLE
ceph: armv7l t.join() timed out exception

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1319,7 +1319,12 @@ def run_in_thread(func, *args, **kwargs):
         # otherwise it will keep polling until timeout or thread stops.
         # wait for INT32_MAX, as python 3.6.8 use int32_t to present the
         # timeout in integer when converting it to nanoseconds
-        timeout = (1 << (32 - 1)) - 1
+        
+        #timeout = (1 << (32 - 1)) - 1
+        
+        # if armv7l arch which is 32bit
+        timeout = 86400.0
+        
     t = RadosThread(func, *args, **kwargs)
 
     # allow the main thread to exit (presumably, avoid a join() on this


### PR DESCRIPTION
"""
ceph: armv7l t.join() timed out exception

the t.join() on L1336 caused a immediate timeout on odroid-hc2 hardware, will prolly wanna make this conditional on armv7l directly.

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: Loren Lisk <loren.lisk@liskl.com>
"""

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---